### PR TITLE
chore: updating readme example language to be js

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The Reactive Platform SDK and examples for JavaScript.
 
 ## Quick Start
 
-```JavaScript
+```js
 import { FeedClient } from "@reactivemarkets/platform-sdk";
 
 const feedClient = new FeedClient({

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -4,7 +4,7 @@ The Reactive Platform SDK for JavaScript. See [Developer Docs](https://reactivem
 
 ## Quick Start
 
-```JavaScript
+```js
 import { FeedClient } from "@reactivemarkets/platform-sdk";
 
 const feedClient = new FeedClient({


### PR DESCRIPTION
Npm doesn't understand the JavaScript language tag only js.