### PR TITLE
fix(sdk): api_key is now used for the query parameters

### DIFF
--- a/packages/sdk/src/feedClient.ts
+++ b/packages/sdk/src/feedClient.ts
@@ -30,7 +30,7 @@ export class FeedClient extends TypedEmitter<IFeedClientEvents> {
             WebSocketCtor,
         } = options;
 
-        this.websocket = new WebSocket(`${feedUrl}?token=${apiKey}`, [], {
+        this.websocket = new WebSocket(`${feedUrl}?api_key=${apiKey}`, [], {
             WebSocket: WebSocketCtor,
         });
         this.websocket.onopen = this.onOpen;


### PR DESCRIPTION
Renamed from token.